### PR TITLE
Add a print button to the graphs.

### DIFF
--- a/app/scripts/vendor/jquery-flot-plugins/jquery.flot.zoombuttons.nens.js
+++ b/app/scripts/vendor/jquery-flot-plugins/jquery.flot.zoombuttons.nens.js
@@ -94,12 +94,32 @@
                     // it can be printed or copied to the clipboard.
                     var srcCanvas = $('canvas.flot-base', $(this).closest('div.graph-region'))[0];
                     var dstCanvas = document.createElement("canvas");
-                    dstCanvas.width = srcCanvas.width;
+                    dstCanvas.width = srcCanvas.width + 200;
                     dstCanvas.height = srcCanvas.height;
                     var dstCtx = dstCanvas.getContext('2d');
                     dstCtx.fillStyle = "#FFFFFF";
-                    dstCtx.fillRect(0, 0, srcCanvas.width, srcCanvas.height);
+                    dstCtx.fillRect(0, 0, dstCanvas.width, srcCanvas.height);
                     dstCtx.drawImage(srcCanvas, 0, 0);
+
+                    // do get legend and draw on same canvas
+                    var legends = $(this).closest('.graph-and-legend').find('.graph-legend');
+                    for (var idx=0; idx < legends.length; idx++) {
+                        var legend = legends[idx];
+                        var color = $(legend).find('.legendcolor')  [0].style.borderColor;
+                        var title = $(legend).find('h5')[0].title;
+                        var position = {
+                            x: srcCanvas.width,
+                            y: 20 + (20 * idx)
+                        };
+                        dstCtx.rect(position.x - 20, position.y, 20, 20);
+                        dstCtx.fillStyle = color;
+                        dstCtx.fill();
+                        dstCtx.fillStyle = 'black';
+                        dstCtx.strokeStyle = 'black';
+                        dstCtx.font = '10pt sans';
+                        dstCtx.fillText(title, position.x + 5, position.y + 14);
+                    }
+
                     var dataURL = dstCanvas.toDataURL("image/png");
                     window.open(dataURL);
                 }

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -2,7 +2,7 @@ html, body{
     margin: 0;
     width: 100%;
     height: 100%;
-    overflow:hidden;
+    /*overflow:hidden;*/
 }
 
 body {


### PR DESCRIPTION
Wish #18: graphs can now be printed or copied to the clipboard. Pasting to e.g. PowerPoint has successfully been tested. Works in Chrome and Firefox; a recent IE has not yet been tested.
NB: how about the graph legend?
