### PR TITLE
Fix IE11 print canvas problem.

### DIFF
--- a/app/scripts/vendor/jquery-flot-plugins/jquery.flot.zoombuttons.nens.js
+++ b/app/scripts/vendor/jquery-flot-plugins/jquery.flot.zoombuttons.nens.js
@@ -123,7 +123,9 @@
                     }
 
                     var dataURL = dstCanvas.toDataURL("image/png");
-                    window.open(dataURL);
+                    var html = "<img src='" + dataURL + "'/>";
+                    var tab = window.open();
+                    tab.document.write(html);
                 }
             });
 


### PR DESCRIPTION
The print button for graphs doesn't currently work in IE 11. This should do the trick.
