### PR TITLE
DDSC management is now under management/ddsc

### DIFF
--- a/app/scripts/settings.js
+++ b/app/scripts/settings.js
@@ -21,7 +21,7 @@ var settings = {
     annotations_url: api + 'annotations/',
     collages_create_url: api + 'collages/',
     collageitems_create_url: api + 'collageitems/',
-    management_ui_url: lizardDomain + 'management',
+    management_ui_url: lizardDomain + 'management/ddsc',
     api_version: 'v2',
     webclient_version: '1.0.0'
 };


### PR DESCRIPTION
Lizard changed the url of ddsc management to group several management pages under /management.
